### PR TITLE
feat: use bsr in `Math_ilog2`

### DIFF
--- a/src/ExtMath.c
+++ b/src/ExtMath.c
@@ -26,6 +26,17 @@ int Math_ilog2(cc_uint32 value) {
 	return r;
 }
 
+static inline cc_uint32 Math_ilog2(cc_uint32 x) {
+	cc_uint32 r = 0;
+	if (x == 0) return 0;
+	#if defined(__i386__) || defined(__x86_64__)
+	__asm__ volatile ("bsr %1, %0" : "=r"(r) : "r"(x));
+	#else
+	while (x >>= 1) r++;
+	#endif
+	return r;
+}
+
 int Math_CeilDiv(int a, int b) {
 	return a / b + (a % b != 0 ? 1 : 0);
 }


### PR DESCRIPTION
Use the native assembler instruction `bsr` in x86.
Added macros to mantain compatibility with other architectures.